### PR TITLE
Update progress text display logic to show for active tasks only i

### DIFF
--- a/FocusZone/Views/Components/ItemList/TaskCard.swift
+++ b/FocusZone/Views/Components/ItemList/TaskCard.swift
@@ -140,11 +140,13 @@ struct TaskCard: View {
                     .lineLimit(2)
                 
                 // Progress text for active tasks
-                if progressInfo.shouldShow && !isCompleted {
+                if progressInfo.shouldShow && !isCompleted &&
+                    overdueMinutesFun() / 60 < 12
+                {
                     Text(getProgressText())
                         .font(AppFonts.caption())
                         .foregroundColor(progressInfo.color)
-                 
+                    
                 }
                 
                 Spacer()


### PR DESCRIPTION
This pull request introduces a conditional enhancement to the `TaskCard` component in the `FocusZone` project to improve the display logic for progress text. The change ensures that the progress text is only shown for active tasks that are not overdue by more than 12 hours.

### Display logic improvement:

* [`FocusZone/Views/Components/ItemList/TaskCard.swift`](diffhunk://#diff-f7bb751fe26039cfd88f8b2551f38af2aa4fcfd05977986244a5e44c7f498ba4L143-R145): Updated the condition in the `TaskCard` view to include a check that the task is not overdue by more than 12 hours (`overdueMinutesFun() / 60 < 12`). This prevents showing progress text for tasks significantly overdue.